### PR TITLE
  feat: support set multi trackers with replace tracker once

### DIFF
--- a/public/tr-web-control/template/dialog-system-replaceTracker.html
+++ b/public/tr-web-control/template/dialog-system-replaceTracker.html
@@ -14,7 +14,7 @@
         <tr>
           <td class="title"><span id="dialog-system-replaceTracker-new-tracker"></span></td>
           <td>
-            <input type="text" id="new-tracker-url" />
+            <textarea type="text" id="new-tracker-url"  placeholder="Warning! New Replace will set one torrents's all trackers. Use string of announce URLs, one per line, and a blank line between tiers."/>
           </td>
         </tr>
 

--- a/public/tr-web-control/template/torrent-attribute.html
+++ b/public/tr-web-control/template/torrent-attribute.html
@@ -590,7 +590,7 @@
               method: 'torrent-set',
               arguments: {
                 ids: system.currentTorrentId,
-                trackerReplace: [tracker.id, URL],
+                trackerReplace: [tracker.id, URL]
               },
             },
             function (data) {

--- a/src/lib/transmission.ts
+++ b/src/lib/transmission.ts
@@ -756,7 +756,7 @@ export const transmission = {
             method: 'torrent-set',
             arguments: {
               ids: result[index].ids,
-              trackerReplace: [parseInt(index), result[index].tracker],
+              trackerList: result[index].tracker
             },
           },
           function (data, tags) {


### PR DESCRIPTION
修正批量修改tracker没法使用的问题。
虽然在torrent-attribute.html 下可以单个替换